### PR TITLE
the nodejs download path with windows x64 has changed

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -28,19 +28,21 @@ function downloadNode(version, callback) {
     async.waterfall(
         [
             function(nodeCallback) {
-                var url = 'http://nodejs.org/dist/' + version;
+                var nodeMirrorUrl =  process.env.NVM_NODEJS_ORG_MIRROR || 'http://nodejs.org/dist/';
+                nodeMirrorUrl = nodeMirrorUrl.endsWith('/') ? nodeMirrorUrl : nodeMirrorUrl + '/';
+                var url = nodeMirrorUrl + version;
                 if (os.arch().toLowerCase() !== 'x64') {
                     return nodeCallback(true, url +'/node.exe');
                 }
 
-                request.head(url + '/x64/node.exe', function(error, response) {
+                request.head(url + '/win-x64/node.exe', function(error, response) {
                     if (error === null) {
                         if (response.statusCode === 404) {
                             return nodeCallback(true, url + '/node.exe');
                         }
 
                         if (response.statusCode === 200) {
-                            return nodeCallback(true, url + '/x64/node.exe');
+                            return nodeCallback(true, url + '/win-x64/node.exe');
                         }
                     }
                     nodeCallback(false, null);


### PR DESCRIPTION
now it is 'win-x64' not 'x64'

add NVM_NODEJS_ORG_MIRROR env support